### PR TITLE
fix electron reload

### DIFF
--- a/electron-app/src/electron.ts
+++ b/electron-app/src/electron.ts
@@ -177,6 +177,9 @@ function createWindow() {
 
     ipcMain.on("renderer-ready", () => {
         win.webContents.send("get-args", args);
+        server.map(() => {
+            win.webContents.send("server-ready", args);
+        })
     });
 
     ipcMain.on("update-install", () => {


### PR DESCRIPTION
When reloading the electron app, for example via CMD-R, the daemon server does not need to be recreated.
Therefore, 'server-ready' needs to be send earlier.